### PR TITLE
Improve Dockerfile with multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,22 @@
+# Stage 1: Build
+FROM alpine:3.14@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae AS build
+
+ENV BLUEBIRD_WARNINGS=0 \
+  NODE_ENV=production \
+  NODE_NO_WARNINGS=1 \
+  NPM_CONFIG_LOGLEVEL=warn \
+  SUPPRESS_NO_CONFIG_WARNING=true
+
+RUN apk add --no-cache \
+  nodejs \
+  npm
+
+COPY package.json ./
+
+RUN npm i --no-optional \
+ && npm cache clean --force
+
+# Stage 2: Runtime
 FROM alpine:3.14@sha256:eb3e4e175ba6d212ba1d6e04fc0782916c08e1c9d7b45892e9796141b1d379ae
 
 ENV BLUEBIRD_WARNINGS=0 \
@@ -9,13 +28,7 @@ ENV BLUEBIRD_WARNINGS=0 \
 RUN apk add --no-cache \
   nodejs
 
-COPY package.json ./
-
-RUN  apk add --no-cache npm \
- && npm i --no-optional \
- && npm cache clean --force \
- && apk del npm
- 
+COPY --from=build /node_modules /node_modules
 COPY . /app
 
 CMD ["node","/app/app.js"]


### PR DESCRIPTION
Update `Dockerfile` to use a multi-stage build for reducing the final image size and separating build and runtime environments.

* **Stage 1: Build**
  - Use `alpine:3.14` as the base image.
  - Set environment variables for build.
  - Install `nodejs` and `npm`.
  - Copy `package.json` and install dependencies.

* **Stage 2: Runtime**
  - Use `alpine:3.14` as the base image.
  - Set environment variables for runtime.
  - Install `nodejs`.
  - Copy `node_modules` from the build stage.
  - Copy application files to `/app`.
  - Set the command to run the application.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/docker/scout-demo-service/pull/42?shareId=8d3d0c23-969f-40d5-b5da-fa4e0c0ff264).